### PR TITLE
Fix broken up sending of escape sequences

### DIFF
--- a/zimodem/zstream.h
+++ b/zimodem/zstream.h
@@ -25,10 +25,11 @@ class ZStream : public ZMode
     ZSerial serial;
     int lastDTR=0;
     unsigned long nextAlarm = millis() + 5000;
+    unsigned const escSeqBufSize = 10;
     const String busyMsg = "\r\n\r\n\r\n\r\n\r\nBUSY\r\n7\r\n";
     
     void switchBackToCommandMode(bool logout);
-    void socketWrite(uint8_t c);
+    void socketWrite(uint8_t* buf, size_t count);
 
     bool isPETSCII();
     bool isEcho();


### PR DESCRIPTION
This is a fix for https://github.com/bozimmerman/Zimodem/issues/31

Zimodem was sending character received on the serial port to the
socket one by one.  As the TCP stack is configured to send out data as
soon as possible (setNoDelay), if multiple characters would be
available to read on the serial port, the first one would always be
sent to the server immediately.  As the IP stack always waits for a
packet sent to be acknowledged by the server before sending the next
one, this would cause a potentially long time gap between the ESC
character introducing the escape sequence and the rest of it.  Some
server software would then interpret the ESC character separately
instead of an escape sequence introduction, causing function keys not
to work.

This fix reads all available characters off the serial port into a
buffer first and then forwards them to the socket in one go.  As a
precaution for escape sequences, it additionally waits for a
millisecond if an escape character has been read before reading
further characters off the serial port.  This makes sure that an
escape sequence is always sent to the server in one packet, with no
gaps introduced in the middle of the sequence.