### PR TITLE
Turn off leds after initialization

### DIFF
--- a/zimodem/zcommand.ino
+++ b/zimodem/zcommand.ino
@@ -218,10 +218,13 @@ void ZCommand::setConfigDefaults()
 #ifdef SUPPORT_LED_PINS
   if(pinSupport[DEFAULT_PIN_AA])
     pinMode(DEFAULT_PIN_AA,OUTPUT);
+    digitalWrite(DEFAULT_PIN_AA, DEFAULT_AA_INACTIVE);
   if(pinSupport[DEFAULT_PIN_WIFI])
     pinMode(DEFAULT_PIN_WIFI,OUTPUT);
+    digitalWrite(DEFAULT_PIN_WIFI, DEFAULT_WIFI_INACTIVE);
   if(pinSupport[DEFAULT_PIN_HS])
     pinMode(DEFAULT_PIN_HS,OUTPUT);
+    digitalWrite(DEFAULT_PIN_HS, DEFAULT_HS_INACTIVE);
 #endif
 }
 


### PR DESCRIPTION
If there is inverted LED, after pinMode OUTPUT this pin become LOW and that will turn on this LED.

So initialize LEDs with default INACTIVE state. Unfortunately it is "too slo", so even like this that LED littlebit flash during init, but it is much better than lights up during whole boot process. 