### PR TITLE
ESP32-S3: Changed default RS-232 PINS regading to Serial1 Arduino pinout

### DIFF
--- a/zimodem/zimodem.ino
+++ b/zimodem/zimodem.ino
@@ -118,16 +118,17 @@ const char compile_date[] = __DATE__ " " __TIME__;
 #  define DEFAULT_PIN_OTH GPIO_NUM_7 // pulse pin
 #  define DEFAULT_PIN_DTR GPIO_NUM_5
 # elif defined(ARDUINO_ESP32S3_DEV) /* Configuration for the Esp32S3 16MB Dev Board */
-#  define DEFAULT_PIN_DCD GPIO_NUM_14
-#  define DEFAULT_PIN_CTS GPIO_NUM_19 // espdev rts pin
-#  define DEFAULT_PIN_RTS GPIO_NUM_20 // espdev cts pin
-#  define DEFAULT_PIN_RI GPIO_NUM_10
-#  define DEFAULT_PIN_DSR GPIO_NUM_12
-#  define DEFAULT_PIN_SND GPIO_NUM_11
-#  define DEFAULT_PIN_OTH GPIO_NUM_46 // pulse pin
-#  define DEFAULT_PIN_DTR GPIO_NUM_13
-#  define DEFAULT_PIN_TXD GPIO_NUM_21
-#  define DEFAULT_PIN_RXD GPIO_NUM_20
+#  define DEFAULT_PIN_DCD GPIO_NUM_5
+#  define DEFAULT_PIN_CTS GPIO_NUM_18
+#  define DEFAULT_PIN_RTS GPIO_NUM_17
+#  define DEFAULT_PIN_RI GPIO_NUM_6
+#  define DEFAULT_PIN_DSR GPIO_NUM_9
+#  define DEFAULT_PIN_SND -1
+#  define DEFAULT_PIN_OTH -1
+#  define DEFAULT_PIN_DTR GPIO_NUM_4
+#  define DEFAULT_PIN_TXD GPIO_NUM_16
+#  define DEFAULT_PIN_RXD GPIO_NUM_15
+#  define DEFAULT_PIN_SD_CS GPIO_NUM_14
 # else                                    /* Configuration for standard ESP32 4 & 8MB boards */
 #  define DEFAULT_PIN_DCD GPIO_NUM_14
 #  define DEFAULT_PIN_CTS GPIO_NUM_13


### PR DESCRIPTION
Regarding to issue #167 I changed default PINS on ESP32-S3 as follows.

It matches to ModemEmulator Board.

Pulse count and SND (probably sound?) are not decided yet, but probably I will use one of 21, 47, 48 as those pins are on AUX2 pin header on ModemEmulator board and there can be some cable interface on 1 header

<img width="633" height="480" alt="image" src="https://github.com/user-attachments/assets/b1c46d69-32c9-4f97-9387-83e10356318c" />

<img width="2048" height="878" alt="image" src="https://github.com/user-attachments/assets/9338b0da-5bde-4978-88ad-163ffb8b1721" />

<img width="2048" height="878" alt="image" src="https://github.com/user-attachments/assets/d83dd45a-c1da-47a9-8015-afb347765430" />
